### PR TITLE
VirtualBox 6.x does support 32 bit VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ VM setup for Malware RE labs. Follow the steps below, **celebrate at the correct
 
 ### Download and install a hypervisor of your choice.
 * Vmware Workstation (you can get a trial license for 30 days)
-* Virtualbox (free) **Note: Use Virtualbox 5.2 or below. 6.0 will not support 32 bit VMs** 
+* Virtualbox (free)
 * Hyper-V (pre-installed in some MSFT enterprise machines)
 
 ### Set up Carrie, the Victim VM


### PR DESCRIPTION
Hi! :wave:

The readme recommends using VirtualBox 5.x, saying that the 6.x version won't support running 32bit VMs, but I just grabbed vbox 6.x, and what their docs say is that it won't run in 32 bit hosts anymore, but it can run 32 bit VMs just fine (I'm currently running one).